### PR TITLE
Limit Number Of Polular Posts

### DIFF
--- a/src/modules/forum/repos/implementations/sequelizePostRepo.ts
+++ b/src/modules/forum/repos/implementations/sequelizePostRepo.ts
@@ -97,6 +97,7 @@ export class PostRepo implements IPostRepo {
     const PostModel = this.models.Post;
     const detailsQuery = this.createBaseDetailsQuery();
     detailsQuery.offset = offset ? offset : detailsQuery.offset;
+    detailsQuery.limit = 5;
     detailsQuery['order'] = [
       ['points', 'DESC'],
     ];


### PR DESCRIPTION
To limit the number of Popular Posts listed, the limit of the query responsible to get the popular posts was set to 5.